### PR TITLE
Ignore unlisted attributes.

### DIFF
--- a/lib/silueta.rb
+++ b/lib/silueta.rb
@@ -41,7 +41,7 @@ module Silueta
 
   def update(attrs)
     attrs.each do |attr, value|
-      public_send(:"#{ attr }=", value)
+      public_send(:"#{ attr }=", value) if respond_to?(:"#{ attr }=")
     end
   end
 

--- a/test/silueta_test.rb
+++ b/test/silueta_test.rb
@@ -38,3 +38,10 @@ test "inheritance" do
 
   assert_equal(User.attributes + [:superpowers], Admin.attributes)
 end
+
+test "ignore unlisted attributes" do
+  user = User.new(name: "Jane", email: "jane@mail.com", age: "25", alignment: "chaotic neutral")
+
+  assert !user.respond_to?(:alignment)
+end
+


### PR DESCRIPTION
Hello there! Sorry for coming out of nowhere with a PR, without a previous discussion. I was about to create an issue for this, but then I saw that the implementation was very simple, so I just did it.

The idea here is to avoid an exception when a call to `.new` has arguments outside the listed `attributes`. Right now this is what happens:

``` ruby
require "silueta"
require "silueta/types"

class User
  include Silueta

  attribute :name
  attribute :age, cast: Types::Integer
end

puts User.new(name: "Foo", age: "21", alignment: "chaotic neutral").attributes
# => undefined method `alignment=' for #<User @attributes={:name=>"Foo", :age=>"21"}>
```

I believe this PR not only solves this (which may or may not be considered a bug), but it also provides a way for Silueta to act as a _whitelister_ of some sorts, for example, to sanitise params from the web.
